### PR TITLE
added eye icon to toggle password visibility

### DIFF
--- a/resumeBuilder/Auth.html
+++ b/resumeBuilder/Auth.html
@@ -48,12 +48,22 @@
         </div>
         <div class="input-group">
           <label for="password">Password</label>
-          <input type="password" id="password" required />
+          <div style="position: relative;">
+            <input type="password" id="password" required style="padding-right: 30px;" />
+            <i class="fas fa-eye" id="togglePassword" 
+              style="position: absolute;right: 10px; top: 50%; transform: translateY(-50%); cursor: pointer;"></i>
+          </div>
         </div>
+
         <div class="input-group hidden" id="confirmPasswordGroup">
           <label for="confirmPassword">Confirm Password</label>
-          <input type="password" id="confirmPassword" />
+          <div style="position: relative;">
+            <input type="password" id="confirmPassword" style="padding-right: 30px;" />
+            <i class="fas fa-eye" id="toggleConfirmPassword"
+              style="position: absolute; right: 10px; top: 50%; transform: translateY(-50%); cursor: pointer;"></i>
+          </div>
         </div>
+
         <p id="errorMsg"></p>
         <button type="submit" class="btn">Login</button>
 

--- a/resumeBuilder/uservalidation.js
+++ b/resumeBuilder/uservalidation.js
@@ -9,6 +9,22 @@ const email = document.getElementById("email");
 const password = document.getElementById("password");
 const confirmPassword = document.getElementById("confirmPassword");
 
+const togglePassword = document.getElementById("togglePassword");
+togglePassword.addEventListener("click", () => {
+  const isPasswordVisible = password.type === "text";
+  password.type = isPasswordVisible ? "password" : "text";
+  togglePassword.classList.toggle("fa-eye");
+  togglePassword.classList.toggle("fa-eye-slash");
+});
+
+const toggleConfirmPassword = document.getElementById("toggleConfirmPassword");
+toggleConfirmPassword.addEventListener("click", () => {
+  const isVisible = confirmPassword.type === "text";
+  confirmPassword.type = isVisible ? "password" : "text";
+  toggleConfirmPassword.classList.toggle("fa-eye");
+  toggleConfirmPassword.classList.toggle("fa-eye-slash");
+});
+
 let isSignup = false;
 
 function toggleForm() {
@@ -84,4 +100,5 @@ authForm.addEventListener("submit", async (e) => {
   } catch (err) {
     errorMsg.textContent = err.message;
   }
+
 });


### PR DESCRIPTION
This PR enhances the login/signup form by adding eye icons to both the Password  and Confirm Password input fields, allowing users to toggle password visibility for easier verification.

Fixes Issue #115 

![image](https://github.com/user-attachments/assets/525fe5e7-3b53-4e56-977d-1df9e17d5887)
